### PR TITLE
Exporting engine config

### DIFF
--- a/backends/backends.h
+++ b/backends/backends.h
@@ -38,6 +38,7 @@ extern BACKEND_OPTIONS global_backend_options;
 extern const char *global_backend_prefix;
 
 extern void *backends_main(void *ptr);
+BACKEND_TYPE backend_select_type(const char *type);
 
 extern BACKEND_OPTIONS backend_parse_data_source(const char *source, BACKEND_OPTIONS backend_options);
 

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -27,6 +27,9 @@
 
 #define config_generate(buffer, only_changed) appconfig_generate(&netdata_config, buffer, only_changed)
 
+#define exporter_get(section, name, value) expconfig_get(&netdata_config, section, name, value)
+#define exporter_get_number(section, name, value) expconfig_get_number(&netdata_config, section, name, value)
+#define exporter_get_boolean(section, name, value) expconfig_get_boolean(&netdata_config, section, name, value)
 
 // ----------------------------------------------------------------------------
 // netdata include files

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -27,9 +27,9 @@
 
 #define config_generate(buffer, only_changed) appconfig_generate(&netdata_config, buffer, only_changed)
 
-#define exporter_get(section, name, value) expconfig_get(&netdata_config, section, name, value)
-#define exporter_get_number(section, name, value) expconfig_get_number(&netdata_config, section, name, value)
-#define exporter_get_boolean(section, name, value) expconfig_get_boolean(&netdata_config, section, name, value)
+#define exporter_get(section, name, value) expconfig_get(&exporting_config, section, name, value)
+#define exporter_get_number(section, name, value) expconfig_get_number(&exporting_config, section, name, value)
+#define exporter_get_boolean(section, name, value) expconfig_get_boolean(&exporting_config, section, name, value)
 
 // ----------------------------------------------------------------------------
 // netdata include files

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -677,6 +677,36 @@ static int load_netdata_conf(char *filename, char overwrite_used) {
     return ret;
 }
 
+static int load_exporter_conf(char *filename, char overwrite_used) {
+    errno = 0;
+
+    int ret = 0;
+
+    if(filename && *filename) {
+        ret = config_load(filename, overwrite_used);
+        if(!ret)
+            error("CONFIG: cannot load config file '%s'.", filename);
+    }
+    else {
+        filename = strdupz_path_subpath(netdata_configured_user_config_dir, "exporting.conf");
+
+        ret = config_load(filename, overwrite_used);
+        if(!ret) {
+            info("CONFIG: cannot load user exporter config '%s'. Will try the stock version.", filename);
+            freez(filename);
+
+            filename = strdupz_path_subpath(netdata_configured_stock_config_dir, "exporting.conf");
+            ret = config_load(filename, overwrite_used);
+            if(!ret)
+                info("CONFIG: cannot load stock exporter config '%s'. Running with internal defaults.", filename);
+        }
+
+        freez(filename);
+    }
+
+    return ret;
+}
+
 int get_system_info(struct rrdhost_system_info *system_info) {
     char *script;
     script = mallocz(sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("system-info.sh") + 2));
@@ -825,6 +855,8 @@ int main(int argc, char **argv) {
         // terminate optstring
         optstring[string_i] ='\0';
         optstring[(num_opts *2)] ='\0';
+
+        load_exporter_conf(NULL, 0);
 
         int opt;
         while( (opt = getopt(argc, argv, optstring)) != -1 ) {
@@ -1056,6 +1088,9 @@ int main(int argc, char **argv) {
     if(!config_loaded)
         load_netdata_conf(NULL, 0);
 
+    // prerare engine for connectors
+    read_exporting_config();
+
     // ------------------------------------------------------------------------
     // initialize netdata
     {
@@ -1071,6 +1106,7 @@ int main(int argc, char **argv) {
         test_clock_boottime();
 
         // prepare configuration environment variables for the plugins
+
 
         get_netdata_configured_variables();
         set_global_environment();

--- a/daemon/main.h
+++ b/daemon/main.h
@@ -6,6 +6,9 @@
 #include "common.h"
 
 extern struct config netdata_config;
+extern struct engine *read_exporting_config();
+
+//extern struct config exporter_config;
 
 #define NETDATA_MAIN_THREAD_RUNNING   CONFIG_BOOLEAN_YES
 #define NETDATA_MAIN_THREAD_EXITING  (CONFIG_BOOLEAN_YES + 1)

--- a/daemon/main.h
+++ b/daemon/main.h
@@ -8,8 +8,6 @@
 extern struct config netdata_config;
 extern struct engine *read_exporting_config();
 
-//extern struct config exporter_config;
-
 #define NETDATA_MAIN_THREAD_RUNNING   CONFIG_BOOLEAN_YES
 #define NETDATA_MAIN_THREAD_EXITING  (CONFIG_BOOLEAN_YES + 1)
 #define NETDATA_MAIN_THREAD_EXITED    CONFIG_BOOLEAN_NO

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -11,8 +11,7 @@ extern int expconfig_get_boolean(struct config *root, const char *section, const
 
 extern int is_valid_connector(char *type);
 extern struct _connector_instance  *ci;
-
-#define EXPORTING_CONF                      "exporting.conf"
+extern struct config exporting_config;
 
 #define EXPORTER_DESTINATION                "destination"
 #define EXPORTER_DESTINATION_DEFAULT        "localhost"

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -5,6 +5,36 @@
 
 #include "daemon/common.h"
 
+extern char *expconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
+extern long long expconfig_get_number(struct config *root, const char *section, const char *name, long long value);
+extern int expconfig_get_boolean(struct config *root, const char *section, const char *name, int value);
+
+extern int is_valid_connector(char *type);
+extern struct _connector_instance  *ci;
+
+#define EXPORTING_CONF                      "exporting.conf"
+
+#define EXPORTER_DESTINATION                "destination"
+#define EXPORTER_DESTINATION_DEFAULT        "localhost"
+
+#define EXPORTER_UPDATE_EVERY               "update every"
+#define EXPORTER_UPDATE_EVERY_DEFAULT       10
+
+#define EXPORTER_BUF_ONFAIL                 "buffer on failures"
+#define EXPORTER_BUF_ONFAIL_DEFAULT         10
+
+#define EXPORTER_TIMEOUT_MS                 "timeout ms"
+#define EXPORTER_TIMEOUT_MS_DEFAULT         10000
+
+#define EXPORTER_SEND_CHART_MATCH           "send charts matching"
+#define EXPORTER_SEND_CHART_MATCH_DEFAULT   "*"
+
+#define EXPORTER_SEND_HOST_MATCH            "send hosts matching"
+#define EXPORTER_SEND_HOST_MATCH_DEFAULT    "localhost *"
+
+#define EXPORTER_SEND_NAMES                 "send names instead of ids"
+#define EXPORTER_SEND_NAMES_DEFAULT         1
+
 struct engine;
 
 struct instance_config {

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -109,7 +109,7 @@ struct engine *read_exporting_config() {
                 struct instance *tmp_instance;
                 char   *instance_name;
 
-                info("  Instance %s on %s", tmp_ci_list->local_ci.instance_name,
+                info("Instance %s on %s", tmp_ci_list->local_ci.instance_name,
                         tmp_ci_list->local_ci.connector_name);
 
                 tmp_instance = (struct instance *)calloc(1, sizeof(struct instance));
@@ -145,10 +145,12 @@ struct engine *read_exporting_config() {
                 tmp_instance->config.send_names_instead_of_ids = exporter_get_boolean(
                         instance_name, EXPORTER_SEND_NAMES, EXPORTER_SEND_NAMES_DEFAULT);
 
+#ifdef NETDATA_INTERNAL_CHECKS
                 info("     Dest=[%s], upd=[%d], buffer=[%d] timeout=[%ld] names=[%d]",
                         tmp_instance->config.destination, tmp_instance->config.update_every,
                         tmp_instance->config.buffer_on_failures, tmp_instance->config.timeoutms,
                         tmp_instance->config.send_names_instead_of_ids);
+#endif
 
                 if (unlikely(!exporting_config_exists) && !engine->config.hostname) {
                         engine->config.hostname = strdupz(

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -11,6 +11,18 @@
  */
 struct engine *read_exporting_config()
 {
+    static struct engine *engine = NULL;
+    struct connector_instance_list {
+        struct connector_instance local_ci;
+        struct connector_instance_list  *next;
+    };
+    struct connector_instance       local_ci;
+    struct connector_instance_list *tmp_ci_list, *tmp_ci_list1;
+    struct connector_instance_list **ci_list;
+
+    if (unlikely(engine))
+        return engine;
+
     // TODO: compose the configuration filename ()
 #if UNIT_TESTING
     // TODO: filename = "./exporting.conf"
@@ -18,27 +30,110 @@ struct engine *read_exporting_config()
 
     // TODO: read and parse the configuration file ()
 
+    // File is already read and parsed
+    ci_list = callocz(sizeof(BACKEND_TYPE), sizeof(struct connector_instance_list *));
+
+    while (get_connector_instance(&local_ci)) {
+        BACKEND_TYPE    backend_type;
+        if (exporter_get_boolean(local_ci.instance_name, "enabled",0)) {
+            backend_type =  backend_select_type(local_ci.connector_name);
+
+            info("Instance %s on %s (connector_type = %d) -- Enabled", local_ci.instance_name,
+                    local_ci.connector_name, backend_type);
+
+            tmp_ci_list  = (struct connector_instance_list *) callocz(1, sizeof(struct connector_instance_list));
+            memcpy(&tmp_ci_list->local_ci, &local_ci, sizeof(local_ci));
+            tmp_ci_list->next = ci_list[backend_type];
+            ci_list[backend_type] = tmp_ci_list;
+        }
+        else
+            info("Instance %s on %s (connector_type = %d) -- Disabled", local_ci.instance_name,
+                    local_ci.connector_name, backend_type);
+    }
+
+    engine = (struct engine *)calloc(1, sizeof(struct engine));
+    // TODO: Check and fill engine fields if actually needed
+
+    for(int i=0; i < sizeof(BACKEND_TYPE); i++) {
+        // For each connector build list
+        tmp_ci_list = ci_list[i];
+
+        // If we have a list of instances for this connector then build it
+        if (tmp_ci_list) {
+            struct connector *tmp_connector;
+
+            tmp_connector = (struct connector *) calloc(1, sizeof(struct connector));
+            tmp_connector->next = engine->connector_root;
+            engine->connector_root = tmp_connector;
+
+            tmp_connector->config.type = i;
+            tmp_connector->engine = engine;
+
+            while (tmp_ci_list) {
+                struct instance *tmp_instance;
+
+                info("  Instance %s on %s", tmp_ci_list->local_ci.instance_name,
+                        tmp_ci_list->local_ci.connector_name);
+
+                tmp_instance = (struct instance *)calloc(1, sizeof(struct instance));
+                tmp_instance->connector = engine->connector_root;
+                tmp_instance->next = engine->connector_root->instance_root;
+                engine->connector_root->instance_root = tmp_instance;
+                tmp_instance->connector = engine->connector_root;
+
+                tmp_instance->config.name = strdupz(tmp_ci_list->local_ci.instance_name);
+                tmp_instance->config.destination = strdupz(
+                        exporter_get(tmp_ci_list->local_ci.instance_name, "destination", "localhost"));
+                tmp_instance->config.update_every = exporter_get_number(tmp_ci_list->local_ci.instance_name,
+                                                                            "update every", 10);
+                tmp_instance->config.buffer_on_failures = exporter_get_number(
+                        tmp_ci_list->local_ci.instance_name, "buffer on failures", 10);
+                tmp_instance->config.timeoutms = exporter_get_number(tmp_ci_list->local_ci.instance_name,
+                                                                         "timeout ms", 10000);
+                tmp_instance->config.charts_pattern = simple_pattern_create(
+                        exporter_get(tmp_ci_list->local_ci.instance_name, "send charts matching", "*"), NULL,
+                        SIMPLE_PATTERN_EXACT);
+                tmp_instance->config.hosts_pattern = simple_pattern_create(
+                        exporter_get(tmp_ci_list->local_ci.instance_name, "send hosts matching", "localhost *"),
+                        NULL, SIMPLE_PATTERN_EXACT);
+                tmp_instance->config.send_names_instead_of_ids = exporter_get_boolean(
+                        tmp_ci_list->local_ci.instance_name, "send names instead of ids", 1);
+
+                info("     Dest=[%s], upd=[%d], buffer=[%d] timeout=[%ld] names=[%d]",
+                        tmp_instance->config.destination, tmp_instance->config.update_every,
+                        tmp_instance->config.buffer_on_failures, tmp_instance->config.timeoutms,
+                        tmp_instance->config.send_names_instead_of_ids);
+
+                tmp_ci_list1 = tmp_ci_list->next;
+                freez(tmp_ci_list);
+                tmp_ci_list = tmp_ci_list1;
+            }
+        }
+    }
+
+    freez(ci_list);
+
     // temporary configuration stub
-    struct engine *engine = (struct engine *)calloc(1, sizeof(struct engine));
-    engine->config.prefix = strdupz("netdata");
-    engine->config.hostname = strdupz("test-host");
-    engine->config.update_every = 3;
-    engine->config.options = BACKEND_SOURCE_DATA_AVERAGE | BACKEND_OPTION_SEND_NAMES;
+//    struct engine *engine = (struct engine *)calloc(1, sizeof(struct engine));
+//    engine->config.prefix = strdupz("netdata");
+//    engine->config.hostname = strdupz("test-host");
+//    engine->config.update_every = 3;
+//    engine->config.options = BACKEND_SOURCE_DATA_AVERAGE | BACKEND_OPTION_SEND_NAMES;
 
-    engine->connector_root = (struct connector *)calloc(1, sizeof(struct connector));
-    engine->connector_root->config.type = BACKEND_TYPE_GRAPHITE;
-    engine->connector_root->engine = engine;
+    //engine->connector_root = (struct connector *)calloc(1, sizeof(struct connector));
+    //engine->connector_root->config.type = BACKEND_TYPE_GRAPHITE;
+    //engine->connector_root->engine = engine;
 
-    engine->connector_root->instance_root = (struct instance *)calloc(1, sizeof(struct instance));
-    struct instance *instance = engine->connector_root->instance_root;
-    instance->connector = engine->connector_root;
-    instance->config.destination = strdupz("localhost");
-    instance->config.update_every = 1;
-    instance->config.buffer_on_failures = 10;
-    instance->config.timeoutms = 10000;
-    instance->config.charts_pattern = strdupz("*");
-    instance->config.hosts_pattern = strdupz("localhost *");
-    instance->config.send_names_instead_of_ids = 1;
+//    engine->connector_root->instance_root = (struct instance *)calloc(1, sizeof(struct instance));
+//    struct instance *instance = engine->connector_root->instance_root;
+//    instance->connector = engine->connector_root;
+//    instance->config.destination = strdupz("localhost");
+//    instance->config.update_every = 1;
+//    instance->config.buffer_on_failures = 10;
+//    instance->config.timeoutms = 10000;
+//    instance->config.charts_pattern = strdupz("*");
+//    instance->config.hosts_pattern = strdupz("localhost *");
+//    instance->config.send_names_instead_of_ids = 1;
 
     return engine;
 }

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -9,14 +9,16 @@
  *
  * @return Returns a filled engine data structure or NULL if there are no connector instances configured.
  */
-struct engine *read_exporting_config()
-{
+struct engine *read_exporting_config() {
+    int instances_to_activate = 0;
+    int exporting_config_exists = 0;
+
     static struct engine *engine = NULL;
     struct connector_instance_list {
         struct connector_instance local_ci;
-        struct connector_instance_list  *next;
+        struct connector_instance_list *next;
     };
-    struct connector_instance       local_ci;
+    struct connector_instance local_ci;
     struct connector_instance_list *tmp_ci_list, *tmp_ci_list1;
     struct connector_instance_list **ci_list;
 
@@ -28,31 +30,66 @@ struct engine *read_exporting_config()
     // TODO: filename = "./exporting.conf"
 #endif
 
+    {
+        char *filename = strdupz_path_subpath(netdata_configured_user_config_dir, EXPORTING_CONF);
+
+        exporting_config_exists = appconfig_load(&netdata_config, filename, 0);
+        if (!exporting_config_exists) {
+            info("CONFIG: cannot load user exporting config '%s'. Will try the stock version.", filename);
+            freez(filename);
+
+            filename = strdupz_path_subpath(netdata_configured_stock_config_dir, EXPORTING_CONF);
+            exporting_config_exists = appconfig_load(&netdata_config, filename, 0);
+            if (!exporting_config_exists)
+                info("CONFIG: cannot load stock exporting config '%s'. Running with internal defaults.", filename);
+        }
+
+        freez(filename);
+
+    };
+
     // TODO: read and parse the configuration file ()
 
-    // File is already read and parsed
+    // Will build a list of instances per connector
+    // TODO: change BACKEND to EXPORTING
     ci_list = callocz(sizeof(BACKEND_TYPE), sizeof(struct connector_instance_list *));
 
     while (get_connector_instance(&local_ci)) {
-        BACKEND_TYPE    backend_type;
-        if (exporter_get_boolean(local_ci.instance_name, "enabled",0)) {
-            backend_type =  backend_select_type(local_ci.connector_name);
+        BACKEND_TYPE backend_type;
 
-            info("Instance %s on %s (connector_type = %d) -- Enabled", local_ci.instance_name,
-                    local_ci.connector_name, backend_type);
+        info("Processing connector (%s)", local_ci.instance_name);
+        if (exporter_get_boolean(local_ci.instance_name, "enabled", 0)) {
+            backend_type = backend_select_type(local_ci.connector_name);
 
-            tmp_ci_list  = (struct connector_instance_list *) callocz(1, sizeof(struct connector_instance_list));
+            info("Instance (%s) on connector (%s) is enabled and scheduled for activation",
+                 local_ci.instance_name, local_ci.connector_name);
+
+            tmp_ci_list = (struct connector_instance_list *) callocz(1, sizeof(struct connector_instance_list));
             memcpy(&tmp_ci_list->local_ci, &local_ci, sizeof(local_ci));
             tmp_ci_list->next = ci_list[backend_type];
             ci_list[backend_type] = tmp_ci_list;
-        }
-        else
-            info("Instance %s on %s (connector_type = %d) -- Disabled", local_ci.instance_name,
-                    local_ci.connector_name, backend_type);
+            instances_to_activate++;
+        } else
+            info("Instance (%s) on connector (%s) is not enabled", local_ci.instance_name, local_ci.connector_name);
+    }
+
+    if (unlikely(!instances_to_activate)) {
+        info("No connector instances to activate");
+        freez(ci_list);
+        return NULL;
     }
 
     engine = (struct engine *)calloc(1, sizeof(struct engine));
     // TODO: Check and fill engine fields if actually needed
+
+    if (exporting_config_exists) {
+
+        engine->config.hostname = strdupz(
+                config_get(CONFIG_SECTION_EXPORTING, "hostname", netdata_configured_hostname));
+        engine->config.prefix = strdupz(config_get(CONFIG_SECTION_EXPORTING, "prefix", "netdata"));
+        engine->config.update_every = config_get_number(CONFIG_SECTION_EXPORTING, EXPORTER_UPDATE_EVERY,
+                                                        EXPORTER_UPDATE_EVERY_DEFAULT);
+    }
 
     for(int i=0; i < sizeof(BACKEND_TYPE); i++) {
         // For each connector build list
@@ -71,6 +108,7 @@ struct engine *read_exporting_config()
 
             while (tmp_ci_list) {
                 struct instance *tmp_instance;
+                char   *instance_name;
 
                 info("  Instance %s on %s", tmp_ci_list->local_ci.instance_name,
                         tmp_ci_list->local_ci.connector_name);
@@ -81,28 +119,45 @@ struct engine *read_exporting_config()
                 engine->connector_root->instance_root = tmp_instance;
                 tmp_instance->connector = engine->connector_root;
 
+                instance_name = tmp_ci_list->local_ci.instance_name;
+
                 tmp_instance->config.name = strdupz(tmp_ci_list->local_ci.instance_name);
+
                 tmp_instance->config.destination = strdupz(
-                        exporter_get(tmp_ci_list->local_ci.instance_name, "destination", "localhost"));
-                tmp_instance->config.update_every = exporter_get_number(tmp_ci_list->local_ci.instance_name,
-                                                                            "update every", 10);
+                        exporter_get(instance_name, EXPORTER_DESTINATION, EXPORTER_DESTINATION_DEFAULT));
+
+                tmp_instance->config.update_every = exporter_get_number(instance_name,
+                                                        EXPORTER_UPDATE_EVERY, EXPORTER_UPDATE_EVERY_DEFAULT);
+
                 tmp_instance->config.buffer_on_failures = exporter_get_number(
-                        tmp_ci_list->local_ci.instance_name, "buffer on failures", 10);
-                tmp_instance->config.timeoutms = exporter_get_number(tmp_ci_list->local_ci.instance_name,
-                                                                         "timeout ms", 10000);
+                        instance_name, EXPORTER_BUF_ONFAIL, EXPORTER_BUF_ONFAIL_DEFAULT);
+
+                tmp_instance->config.timeoutms = exporter_get_number(instance_name,
+                                                     EXPORTER_TIMEOUT_MS, EXPORTER_TIMEOUT_MS_DEFAULT);
+
                 tmp_instance->config.charts_pattern = simple_pattern_create(
-                        exporter_get(tmp_ci_list->local_ci.instance_name, "send charts matching", "*"), NULL,
-                        SIMPLE_PATTERN_EXACT);
+                        exporter_get(instance_name,
+                           EXPORTER_SEND_CHART_MATCH, EXPORTER_SEND_CHART_MATCH_DEFAULT), NULL, SIMPLE_PATTERN_EXACT);
+
                 tmp_instance->config.hosts_pattern = simple_pattern_create(
-                        exporter_get(tmp_ci_list->local_ci.instance_name, "send hosts matching", "localhost *"),
+                        exporter_get(instance_name, EXPORTER_SEND_HOST_MATCH, EXPORTER_SEND_HOST_MATCH_DEFAULT),
                         NULL, SIMPLE_PATTERN_EXACT);
+
                 tmp_instance->config.send_names_instead_of_ids = exporter_get_boolean(
-                        tmp_ci_list->local_ci.instance_name, "send names instead of ids", 1);
+                        instance_name, EXPORTER_SEND_NAMES, EXPORTER_SEND_NAMES_DEFAULT);
 
                 info("     Dest=[%s], upd=[%d], buffer=[%d] timeout=[%ld] names=[%d]",
                         tmp_instance->config.destination, tmp_instance->config.update_every,
                         tmp_instance->config.buffer_on_failures, tmp_instance->config.timeoutms,
                         tmp_instance->config.send_names_instead_of_ids);
+
+                if (unlikely(!exporting_config_exists) && !engine->config.hostname) {
+                        engine->config.hostname = strdupz(
+                            config_get(instance_name, "hostname", netdata_configured_hostname));
+                    engine->config.prefix = strdupz(config_get(instance_name, "prefix", "netdata"));
+                    engine->config.update_every = config_get_number(instance_name, "update_every",
+                                                                    EXPORTER_UPDATE_EVERY_DEFAULT);
+                }
 
                 tmp_ci_list1 = tmp_ci_list->next;
                 freez(tmp_ci_list);

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -33,13 +33,13 @@ struct engine *read_exporting_config() {
     {
         char *filename = strdupz_path_subpath(netdata_configured_user_config_dir, EXPORTING_CONF);
 
-        exporting_config_exists = appconfig_load(&netdata_config, filename, 0);
+        exporting_config_exists = appconfig_load(&exporting_config, filename, 0);
         if (!exporting_config_exists) {
             info("CONFIG: cannot load user exporting config '%s'. Will try the stock version.", filename);
             freez(filename);
 
             filename = strdupz_path_subpath(netdata_configured_stock_config_dir, EXPORTING_CONF);
-            exporting_config_exists = appconfig_load(&netdata_config, filename, 0);
+            exporting_config_exists = appconfig_load(&exporting_config, filename, 0);
             if (!exporting_config_exists)
                 info("CONFIG: cannot load stock exporting config '%s'. Running with internal defaults.", filename);
         }
@@ -61,7 +61,7 @@ struct engine *read_exporting_config() {
         if (exporter_get_boolean(local_ci.instance_name, "enabled", 0)) {
             backend_type = backend_select_type(local_ci.connector_name);
 
-            info("Instance (%s) on connector (%s) is enabled and scheduled for activation",
+            info(" Instance (%s) on connector (%s) is enabled and scheduled for activation",
                  local_ci.instance_name, local_ci.connector_name);
 
             tmp_ci_list = (struct connector_instance_list *) callocz(1, sizeof(struct connector_instance_list));
@@ -83,11 +83,10 @@ struct engine *read_exporting_config() {
     // TODO: Check and fill engine fields if actually needed
 
     if (exporting_config_exists) {
-
         engine->config.hostname = strdupz(
-                config_get(CONFIG_SECTION_EXPORTING, "hostname", netdata_configured_hostname));
-        engine->config.prefix = strdupz(config_get(CONFIG_SECTION_EXPORTING, "prefix", "netdata"));
-        engine->config.update_every = config_get_number(CONFIG_SECTION_EXPORTING, EXPORTER_UPDATE_EVERY,
+                exporter_get(CONFIG_SECTION_EXPORTING, "hostname", netdata_configured_hostname));
+        engine->config.prefix = strdupz(exporter_get(CONFIG_SECTION_EXPORTING, "prefix", "netdata"));
+        engine->config.update_every = exporter_get_number(CONFIG_SECTION_EXPORTING, EXPORTER_UPDATE_EVERY,
                                                         EXPORTER_UPDATE_EVERY_DEFAULT);
     }
 
@@ -155,7 +154,7 @@ struct engine *read_exporting_config() {
                         engine->config.hostname = strdupz(
                             config_get(instance_name, "hostname", netdata_configured_hostname));
                     engine->config.prefix = strdupz(config_get(instance_name, "prefix", "netdata"));
-                    engine->config.update_every = config_get_number(instance_name, "update_every",
+                    engine->config.update_every = config_get_number(instance_name, EXPORTER_UPDATE_EVERY,
                                                                     EXPORTER_UPDATE_EVERY_DEFAULT);
                 }
 

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -2,6 +2,8 @@
 
 #include "../libnetdata.h"
 
+int     _backends=0;    // number of backend sections we have
+
 #define CONFIG_FILE_LINE_MAX ((CONFIG_MAX_NAME + CONFIG_MAX_VALUE + 1024) * 2)
 
 // ----------------------------------------------------------------------------
@@ -42,6 +44,64 @@ struct section {
                             // readers are protected using the rwlock in avl_tree_lock
 };
 
+// Get a list of instances and where do they refer
+struct _connector_instance {
+    struct section  *connector;        // actual connector
+    struct section  *instance;         // This instance
+    struct _connector_instance *next;   // Next instance
+};
+
+struct _connector_instance  *ci = NULL;
+
+int get_connector_instance(struct connector_instance *target_ci) {
+    static struct _connector_instance *local_ci = NULL;
+
+    if (target_ci == NULL) {
+        local_ci = ci;
+        return 1;
+    }
+    if (local_ci == NULL)
+        local_ci = ci;
+    else {
+        local_ci = local_ci->next;
+        if (local_ci == NULL)
+            return 0;
+    }
+
+    strcpy(target_ci->instance_name, local_ci->instance->name);
+    strcpy(target_ci->connector_name, local_ci->connector->name);
+
+    return 1;
+}
+
+int is_valid_connector(char *type){
+    if (unlikely(!type))
+        return 0;
+
+    if(!strcmp(type, "graphite") || !strcmp(type, "graphite:plaintext")) {
+            return 1;
+        }
+        else if(!strcmp(type, "opentsdb") || !strcmp(type, "opentsdb:telnet")) {
+            return 1;
+        }
+        else if(!strcmp(type, "opentsdb:http") || !strcmp(type, "opentsdb:https")) {
+            return 1;
+        }
+        else if (!strcmp(type, "json") || !strcmp(type, "json:plaintext")) {
+            return 1;
+        }
+        else if (!strcmp(type, "prometheus_remote_write")) {
+            return  1;
+        }
+        else if (!strcmp(type, "kinesis") || !strcmp(type, "kinesis:plaintext")) {
+            return 1;
+        }
+        else if (!strcmp(type, "mongodb") || !strcmp(type, "mongodb:plaintext")) {
+            return 1;
+        }
+
+    return 0;
+}
 
 // ----------------------------------------------------------------------------
 // locking
@@ -239,6 +299,62 @@ cleanup:
         config_section_unlock(co_new);
     config_section_unlock(co_old);
     return ret;
+}
+
+
+//#define exporter_get(section, name, value) expconfig_get(&exporter_config, section, name, value)
+//#define exporter_get_number(section, name, value) expconfig_get_number(&exporter_config, section, name, value)
+//#define exporter_get_boolean(section, name, value) expconfig_get_boolean(&exporter_config, section, name, value)
+
+char *expconfig_get(struct config *root, const char *section, const char *name, const char *default_value)
+{
+    struct _connector_instance *local_ci;
+
+    local_ci = ci;
+    while(local_ci) {
+        if (strcmp(local_ci->instance->name, section) == 0)
+            break;
+        local_ci = local_ci->next;
+    }
+    if (!local_ci)
+        return NULL;
+    return appconfig_get(root, local_ci->instance->name, name,
+            appconfig_get(root, local_ci->connector->name, name,
+                    appconfig_get(root, "connector_global", name, default_value)));
+}
+
+int expconfig_get_boolean(struct config *root, const char *section, const char *name, int default_value)
+{
+    struct _connector_instance *local_ci;
+
+    local_ci = ci;
+    while(local_ci) {
+        if (strcmp(local_ci->instance->name, section) == 0)
+            break;
+        local_ci = local_ci->next;
+    }
+    if (!local_ci)
+        return 0;
+    return appconfig_get_boolean(root, local_ci->instance->name, name,
+                                 appconfig_get_boolean(root, local_ci->connector->name, name,
+                                                       appconfig_get_boolean(root, "connector_global", name, 0)));
+}
+
+long long  expconfig_get_number(struct config *root, const char *section, const char *name, long long default_value)
+{
+    struct _connector_instance *local_ci;
+
+    local_ci = ci;
+    while(local_ci) {
+        if (strcmp(local_ci->instance->name, section) == 0)
+            break;
+        local_ci = local_ci->next;
+    }
+    if (!local_ci)
+        return 0;
+    return appconfig_get_number(root, local_ci->instance->name, name,
+                                appconfig_get_number(root, local_ci->connector->name, name,
+                                                     appconfig_get_number(root, "connector_global", name, 0)));
 }
 
 char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value)
@@ -440,12 +556,21 @@ int appconfig_load(struct config *root, char *filename, int overwrite_used)
 {
     int line = 0;
     struct section *co = NULL;
+    int   is_exporter_config = 0;
+    int   is_backend_config  = 0;
+    int   have_backend_config = 0;
+    int     item = 0;
+    char  items[120][CONFIG_MAX_NAME];
 
     char buffer[CONFIG_FILE_LINE_MAX + 1], *s;
 
     if(!filename) filename = CONFIG_DIR "/" CONFIG_FILENAME;
 
     debug(D_CONFIG, "CONFIG: opening config file '%s'", filename);
+
+    //fprintf(stderr, "Calling appconfgload %s \n", filename);
+
+    is_exporter_config = (strstr(filename, "exporting.conf") != NULL);
 
     FILE *fp = fopen(filename, "r");
     if(!fp) {
@@ -468,6 +593,18 @@ int appconfig_load(struct config *root, char *filename, int overwrite_used)
             // new section
             s[len - 1] = '\0';
             s++;
+
+            is_backend_config = !(strcmp(s,CONFIG_SECTION_BACKEND));
+            if (!have_backend_config)
+                have_backend_config = is_backend_config;
+
+            if (is_backend_config) {
+                if (_backends) {
+                    sprintf(buffer, CONFIG_SECTION_BACKEND "/%d", _backends);
+                    s = buffer;
+                }
+                _backends++;
+            }
 
             co = appconfig_section_find(root, s);
             if(!co) co = appconfig_section_create(root, s);
@@ -502,7 +639,34 @@ int appconfig_load(struct config *root, char *filename, int overwrite_used)
 
         struct config_option *cv = appconfig_option_index_find(co, name, 0);
 
-        if(!cv) cv = appconfig_value_create(co, name, value);
+        if(!cv) {
+            cv = appconfig_value_create(co, name, value);
+            if (is_exporter_config || is_backend_config) {
+//                if (is_backend_config) {
+//                    fprintf(stderr, "Adding backend name = %s on %d\n", name, item);
+//                    strcpy(items[item], name);
+//                    item++;
+//                }
+                if (!strcmp(name,"type")) {
+                    if (is_valid_connector(value)) {
+                        struct section *local_connector = appconfig_section_find(root, value);
+                        if (local_connector == NULL)
+                            info("Instance %s will not take effect no connector defined for %s", co->name, value);
+                        else {
+                            info("Adding instance %s to connector %s", co->name, local_connector->name);
+                            struct _connector_instance *local_ci = callocz(1, sizeof(ci));
+                            local_ci->instance = co;
+                            local_ci->connector = local_connector;
+                            local_ci->next = ci;
+                            ci = local_ci;
+                        }
+                    }
+                    else  {
+                        info("Ignoring unknown connector %s specified for version " VERSION, value);
+                    }
+                }
+            }
+        }
         else {
             if(((cv->flags & CONFIG_VALUE_USED) && overwrite_used) || !(cv->flags & CONFIG_VALUE_USED)) {
                 debug(D_CONFIG, "CONFIG: line %d of file '%s', overwriting '%s/%s'.", line, filename, co->name, cv->name);
@@ -516,6 +680,22 @@ int appconfig_load(struct config *root, char *filename, int overwrite_used)
     }
 
     fclose(fp);
+
+    // Dump all the exporters
+
+//    if (is_exporter_config) {
+//        struct connector_instance local_ci;
+//
+//        while (get_connector_instance(&local_ci))
+//            fprintf(stderr, "Instance %s on %s\n", local_ci.instance_name, local_ci.connector_name);
+//    }
+
+//    if (have_backend_config) {
+//        fprintf(stderr,"Backend config items %d \n", item);
+//        for (int i=0; i < item; i++) {
+//            fprintf(stderr,"Backend config [%s]\n", items[i]);
+//        }
+//    }
 
     return 1;
 }

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -91,6 +91,7 @@
 #define CONFIG_SECTION_HEALTH   "health"
 #define CONFIG_SECTION_BACKEND  "backend"
 #define CONFIG_SECTION_STREAM   "stream"
+#define CONFIG_SECTION_EXPORTING "connector_global"
 
 // these are used to limit the configuration names and values lengths
 // they are not enforced by config.c functions (they will strdup() all strings, no matter of their length)
@@ -141,9 +142,6 @@ extern int appconfig_section_compare(void *a, void *b);
 
 extern int config_parse_duration(const char* string, int* result);
 
-extern char *expconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
-extern long long expconfig_get_number(struct config *root, const char *section, const char *name, long long value);
-extern int expconfig_get_boolean(struct config *root, const char *section, const char *name, int value);
 
 extern int get_connector_instance(struct connector_instance *target_ci);
 

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -92,6 +92,8 @@
 #define CONFIG_SECTION_BACKEND  "backend"
 #define CONFIG_SECTION_STREAM   "stream"
 #define CONFIG_SECTION_EXPORTING "connector_global"
+#define EXPORTING_CONF           "exporting.conf"
+
 
 // these are used to limit the configuration names and values lengths
 // they are not enforced by config.c functions (they will strdup() all strings, no matter of their length)

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -103,6 +103,11 @@ struct config {
     avl_tree_lock index;
 };
 
+struct connector_instance {
+    char    instance_name[CONFIG_MAX_NAME+1];
+    char    connector_name[CONFIG_MAX_NAME+1];
+};
+
 #define CONFIG_BOOLEAN_INVALID 100  // an invalid value to check for validity (used as default initialization when needed)
 
 #define CONFIG_BOOLEAN_NO   0       // disabled
@@ -135,5 +140,11 @@ extern void appconfig_generate(struct config *root, BUFFER *wb, int only_changed
 extern int appconfig_section_compare(void *a, void *b);
 
 extern int config_parse_duration(const char* string, int* result);
+
+extern char *expconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
+extern long long expconfig_get_number(struct config *root, const char *section, const char *name, long long value);
+extern int expconfig_get_boolean(struct config *root, const char *section, const char *name, int value);
+
+extern int get_connector_instance(struct connector_instance *target_ci);
 
 #endif /* NETDATA_CONFIG_H */


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Read a new `exporting.conf` file that define multiple connectors and instances for archiving

##### Component Name

##### Additional Information

The new file contains a section
`[connector_global]`

That specifies the default values for all connectors / instances

A section with the available connectors e.g.

`[graphite]`

And sections with instances that link to a connector

Example:

```
[connector_global]
    # host tags = 
    enabled = no
    data source = average
    prefix = netdata
    hostname = arch-esxi
    update every = 99
    buffer on failures = 99999
    timeout ms = 999999
    send names instead of ids = yes
    send charts matching = *
    send hosts matching = localhost *

[graphite]
    update every = 10
    timeout ms = 20000

[opentsdb]
    # host tags = 
    enabled = no
    # data source = average
    # prefix = netdata
    # hostname = arch-esxi
    update every = 9
    # buffer on failures = 10
    # timeout ms = 20000
    send names instead of ids = no
    # send charts matching = *
    # send hosts matching = localhost *

[my_own_name]
    enabled = no
    type = opentsdb
    destination = localhost
    update every = 5

[my_server]
    enabled = yes
    type = opentsdb
    #update every = 4
    destination = another_host
```
